### PR TITLE
Solr 3.x and Solr 4.x images added

### DIFF
--- a/solr/solr3.x/Dockerfile
+++ b/solr/solr3.x/Dockerfile
@@ -1,0 +1,15 @@
+FROM blinkreaction/drupal-solr:base
+
+MAINTAINER Leonid Makarov <leonid.makarov@blinkreaction.com>
+
+# SOLR 3.x version and mirror
+ENV SOLR_VERSION 3.6.2
+ENV SOLR_MIRROR http://archive.apache.org/dist/lucene/solr
+ENV SOLR apache-solr-$SOLR_VERSION
+
+ENV SOLR_COLLECTION_PATH /opt/solr/$SOLR/example/solr
+
+# Download and install solr
+RUN /opt/install.sh
+
+CMD /opt/startup.sh;

--- a/solr/solr4.x/Dockerfile
+++ b/solr/solr4.x/Dockerfile
@@ -1,0 +1,15 @@
+FROM blinkreaction/drupal-solr:base
+
+MAINTAINER Leonid Makarov <leonid.makarov@blinkreaction.com>
+
+# SOLR 4.x version and mirror
+ENV SOLR_VERSION 4.10.4
+ENV SOLR_MIRROR http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr
+ENV SOLR solr-$SOLR_VERSION
+
+ENV SOLR_COLLECTION_PATH /opt/solr/$SOLR/example/solr
+
+# Download and install solr
+RUN /opt/install.sh
+
+CMD /opt/startup.sh;

--- a/solr/solr4.x/Dockerfile
+++ b/solr/solr4.x/Dockerfile
@@ -7,7 +7,7 @@ ENV SOLR_VERSION 4.10.4
 ENV SOLR_MIRROR http://www.mirrorservice.org/sites/ftp.apache.org/lucene/solr
 ENV SOLR solr-$SOLR_VERSION
 
-ENV SOLR_COLLECTION_PATH /opt/solr/$SOLR/example/solr
+ENV SOLR_COLLECTION_PATH /opt/solr/$SOLR/example/solr/collection1
 
 # Download and install solr
 RUN /opt/install.sh


### PR DESCRIPTION
Usage example in docker-compose.yml
```
solr:
  image: IMAGE
  ports:
    - "8983:8983"
  volumes:
    # Map config files from your solr module
    - "<path to your module>/solr-conf/<SOLRVERSION>:/var/lib/solr/conf"
```